### PR TITLE
Add ReflectionUtil test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/tech/bonda/reordify/util/ReflectionUtil.java
+++ b/src/main/java/tech/bonda/reordify/util/ReflectionUtil.java
@@ -22,5 +22,6 @@ public class ReflectionUtil {
         // Optionally, you can also set the total count if needed
         Field totalField = Paging.class.getDeclaredField("total");
         totalField.setAccessible(true);
+        totalField.set(playlistTracks, tracks.size());
     }
 }

--- a/src/test/java/tech/bonda/reordify/util/ReflectionUtilTest.java
+++ b/src/test/java/tech/bonda/reordify/util/ReflectionUtilTest.java
@@ -1,0 +1,30 @@
+package tech.bonda.reordify.util;
+
+import org.junit.jupiter.api.Test;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
+import se.michaelthelin.spotify.model_objects.specification.Playlist;
+import se.michaelthelin.spotify.model_objects.specification.PlaylistTrack;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReflectionUtilTest {
+
+    @Test
+    public void setPlaylistTracks_updatesItemsAndTotal() {
+        Playlist playlist = new Playlist.Builder().build();
+
+        PlaylistTrack track1 = new PlaylistTrack.Builder().build();
+        PlaylistTrack track2 = new PlaylistTrack.Builder().build();
+        List<PlaylistTrack> tracks = Arrays.asList(track1, track2);
+
+        ReflectionUtil.setPlaylistTracks(playlist, tracks);
+
+        Paging<PlaylistTrack> paging = playlist.getTracks();
+        assertNotNull(paging, "Paging should not be null");
+        assertArrayEquals(tracks.toArray(), paging.getItems());
+        assertEquals(2, paging.getTotal());
+    }
+}


### PR DESCRIPTION
## Summary
- set total track count in `ReflectionUtil.setPlaylistTracks`
- add JUnit dependency
- test ReflectionUtil with two playlist tracks

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6840102d97748325a41a21fbb696e186